### PR TITLE
update requirements.txt for PEP508

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ numpy
 astropy
 sqlalchemy
 pandas
-git+https://github.com/SAGUARO-MMA/sassy_q3c_models
+sassy_q3c_models @ git+https://github.com/SAGUARO-MMA/sassy_q3c_models


### PR DESCRIPTION
The way I added sassy_q3c_models to the requirements file in PR #6 is incompatible with setuptools (used in your setup.py). I think this new way of specifying requirements should fix the problem.