### PR TITLE
Cleanup imports

### DIFF
--- a/kne_cand_vetting/catalogs.py
+++ b/kne_cand_vetting/catalogs.py
@@ -4,10 +4,8 @@
 # +
 # import(s)
 # -
-from astropy.io import ascii
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from sassy_q3c_models import *
 from sassy_q3c_models.milliquas_q3c_orm import MilliQuasQ3cRecord
 from sassy_q3c_models.milliquas_q3c_orm_filters import milliquas_q3c_orm_filters
 from sassy_q3c_models.asassn_q3c_orm import AsAssnQ3cRecord
@@ -218,7 +216,7 @@ def gaia_query(ra,dec,rad=2):
     ----------
     ra, dec : array of floats
         degrees
-    radius : float
+    rad : float
         default = 2, arcseconds
 
     RETURNS

--- a/kne_cand_vetting/galaxy_matching.py
+++ b/kne_cand_vetting/galaxy_matching.py
@@ -1,6 +1,5 @@
 # JCR May 2022, adapted from Charlie Kilpatrick, Vic Dong et al.
 
-from astropy.io import ascii
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 import numpy as np
@@ -16,10 +15,8 @@ from sassy_q3c_models.sdss12photoz_q3c_orm_filters import sdss12photoz_q3c_orm_f
 
 from typing import Optional
 from astropy.coordinates import SkyCoord
-from astropy import cosmology
 from astropy import units as u
 from astropy.cosmology import FlatLambdaCDM
-from astropy.cosmology import z_at_value
 cosmo = FlatLambdaCDM(H0=69.6 * u.km / u.s / u.Mpc, Tcmb0=2.725 * u.K, Om0=0.3)
 
 import argparse

--- a/kne_cand_vetting/survey_phot.py
+++ b/kne_cand_vetting/survey_phot.py
@@ -1,13 +1,11 @@
 ### Query public surveys for photometric detections prior to GW event
 ### Currently working on ZTF only
 
-from astropy.coordinates import SkyCoord
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from astropy.time import Time
 import os
 import requests
-import argparse
 from datetime import datetime, timedelta
 import sys
 import time
@@ -16,21 +14,18 @@ import numpy as np
 import glob
 from astropy.io import fits
 import datetime
-import subprocess
-import importlib
 import argparse
 from collections import OrderedDict
 import json
+import csv
+import re
 
-import codecs
 from fundamentals.stats import rolling_window_sigma_clip
-from fundamentals.renderer import list_of_dictionaries
 from operator import itemgetter
 from past.utils import old_div
 
 from sassy_q3c_models.ztf_q3c_orm import ZtfQ3cRecord
-from sassy_q3c_models.ztf_q3c_orm_filters import *
-from sassy_q3c_models.ztf_q3c_orm_cli import *
+from sassy_q3c_models.ztf_q3c_orm_filters import ztf_q3c_orm_filters
 
 # constants -- are these still needed?
 DB_HOST = os.getenv('POSTGRES_HOST', 'localhost')
@@ -281,7 +276,7 @@ def stack_photometry(magnitudes, binningDays=1.):
         distinctMjds = {}
         for mjd, flx, err, lim in zip(data["mjds"], data["mags"], data["magErrs"], data["lim5sig"]):
             # DICT KEY IS THE UNIQUE INTEGER MJD
-            key = str(int(math.floor(mjd / float(binningDays))))
+            key = str(int(np.floor(mjd / float(binningDays))))
             # FIRST DATA POINT OF THE NIGHTS? CREATE NEW DATA SET
             if key not in distinctMjds:
                 distinctMjds[key] = {
@@ -308,11 +303,11 @@ def stack_photometry(magnitudes, binningDays=1.):
             summedMagnitudes[fil]["mags"].append(meanFLux)
             # GIVE ME THE COMBINED ERROR
             combError = sum(v["magErrs"]) / len(v["magErrs"]
-                                                ) / math.sqrt(len(v["magErrs"]))
+                                                ) / np.sqrt(len(v["magErrs"]))
             summedMagnitudes[fil]["magErrs"].append(combError)
             # 5-sigma limits
             # combine duJy errors in quadrature, convert to cgs
-            combFnuErr = math.sqrt(sum(mag**2 for mag in v["magErrs"])) * 1e-29
+            combFnuErr = np.sqrt(sum(mag**2 for mag in v["magErrs"])) * 1e-29
             comb5SigLimit = -2.5*np.log10(5*combFnuErr) - 48.6
             summedMagnitudes[fil]["lim5sig"].append(comb5SigLimit)
             # GIVE ME NUMBER OF DATA POINTS COMBINED
@@ -412,9 +407,9 @@ def SAGUARO_forcedphot(RA: float, Dec: float, CSSField: str):
             header = hdr[1].header
             mjd = header['MJD']
         mag, magerr, flag, ra, dec = np.loadtxt(f,usecols=(3,5,7,11,12),unpack=True)
-        target_mag = mag[(ra>args.ra-radius)&(ra<args.ra+radius)&(dec>args.dec-radius)&(dec<args.dec+radius)]
-        target_magerr = magerr[(ra>args.ra-radius)&(ra<args.ra+radius)&(dec>args.dec-radius)&(dec<args.dec+radius)]
-        target_flag = flag[(ra>args.ra-radius)&(ra<args.ra+radius)&(dec>args.dec-radius)&(dec<args.dec+radius)]
+        target_mag = mag[(ra>RA-radius)&(ra<RA+radius)&(dec>Dec-radius)&(dec<Dec+radius)]
+        target_magerr = magerr[(ra>RA-radius)&(ra<RA+radius)&(dec>Dec-radius)&(dec<Dec+radius)]
+        target_flag = flag[(ra>RA-radius)&(ra<RA+radius)&(dec>Dec-radius)&(dec<Dec+radius)]
         try:
             SAGUAROPhot.append({'mjd':mjd,
                                 'mag':target_mag[0],

--- a/kne_cand_vetting/survey_phot.py
+++ b/kne_cand_vetting/survey_phot.py
@@ -13,7 +13,6 @@ import logging
 import numpy as np
 import glob
 from astropy.io import fits
-import datetime
 import argparse
 from collections import OrderedDict
 import json

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@
 numpy
 astropy
 sqlalchemy
-pandas
 fundamentals
-sassy_q3c_models @ git+https://github.com/SAGUARO-MMA/sassy_q3c_models
+sassy_q3c_models @ git+https://github.com/SAGUARO-MMA/sassy_q3c_models@update_reqs


### PR DESCRIPTION
This cleans up a few of the unused imports and gets rid of several `import *`, which have been confusing us.

I'm temporarily switching to the `update_reqs` branch of `sassy_q3c_models` until @pndaly merges https://github.com/SAGUARO-MMA/sassy_q3c_models/pull/5. Then we can switch it back to the main branch.

Pandas does not seem to be used, so I removed it.